### PR TITLE
Fix crash with Seasonals

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ repositories {
         }
     }
     maven {
-        name = "Progwml6 maven"
-        url = "https://dvs1.progwml6.com/files/maven/"
+        name "Jared's maven"
+        url "https://maven.blamejared.com/"
     }
     maven {
         name = "Abnormals Maven"

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,6 @@ nethers_delight_version=3971576
 blueprint_version=3971299
 neapolitan_version=3912007
 atmospheric_version=4415516
-seasonals_version=4030579
+seasonals_version=4709041
 respiteful_version=4433294
 registrate_version=MC1.19-1.1.5

--- a/src/main/java/net/brdle/collectorsreap/common/item/food/Nutrition.java
+++ b/src/main/java/net/brdle/collectorsreap/common/item/food/Nutrition.java
@@ -204,7 +204,7 @@ public class Nutrition {
         .effect(() -> new MobEffectInstance(ModCompat.getHarmony().get(), 40, 2), 1.0F).build();
     public static final FoodProperties PUMPKIN_GUMMY = (new FoodProperties.Builder())
         .nutrition(2).saturationMod(0.0F).alwaysEat()
-        .effect(() -> new MobEffectInstance(ModCompat.getFallFlavor().get(), 100, 0), 1.0F)
+        .effect(() -> new MobEffectInstance(ModCompat.getStuffed().get(), 100, 0), 1.0F)
         .effect(() -> new MobEffectInstance(MobEffects.SATURATION, 200, 0), 1.0F).build();
     public static final FoodProperties ALOE_GUMMY = (new FoodProperties.Builder())
         .nutrition(2).saturationMod(0.0F).alwaysEat()

--- a/src/main/java/net/brdle/collectorsreap/compat/ModCompat.java
+++ b/src/main/java/net/brdle/collectorsreap/compat/ModCompat.java
@@ -61,8 +61,8 @@ public class ModCompat {
 		return (ModList.get().isLoaded("atmospheric")) ? AtmosphericCompat.RELIEF : () -> MobEffects.CONFUSION;
 	}
 
-	public static Supplier<MobEffect> getFallFlavor() {
-		return (ModList.get().isLoaded("seasonals")) ? SeasonalsCompat.FALL_FLAVOR : () -> MobEffects.CONFUSION;
+	public static Supplier<MobEffect> getStuffed() {
+		return (ModList.get().isLoaded("seasonals")) ? SeasonalsCompat.STUFFED : () -> MobEffects.CONFUSION;
 	}
 
 	public static Supplier<MobEffect> getVitality() {

--- a/src/main/java/net/brdle/collectorsreap/compat/SeasonalsCompat.java
+++ b/src/main/java/net/brdle/collectorsreap/compat/SeasonalsCompat.java
@@ -1,9 +1,9 @@
 package net.brdle.collectorsreap.compat;
 
-import com.cosmicgelatin.seasonals.core.registry.SeasonalsEffects;
+import com.cosmicgelatin.seasonals.core.registry.SeasonalsMobEffects;
 import net.minecraft.world.effect.MobEffect;
 import java.util.function.Supplier;
 
 public class SeasonalsCompat {
-	public static Supplier<MobEffect> FALL_FLAVOR = SeasonalsEffects.FALL_FLAVOR;
+	public static Supplier<MobEffect> STUFFED = SeasonalsMobEffects.STUFFED;
 }


### PR DESCRIPTION
This PR fixes the incompatibility with Seasonals version 4.1.0 by changing the Fall Flavor effect to the Stuffed effect for the Pumpkin gummy. This should close #18